### PR TITLE
#165485037 Fix usertype not in signin/signup response (DB)

### DIFF
--- a/server/controllers/Auth.js
+++ b/server/controllers/Auth.js
@@ -27,7 +27,7 @@ class AuthController {
         const { id: userId, type: userType } = newUser;
         const token = createToken({ userId, userType });
         const {
-          password, isadmin, type, ...signupDetails
+          password, isadmin, ...signupDetails
         } = newUser;
         const newSignup = { token, ...signupDetails };
         return res.header('x-auth-token', token).status(201).json({
@@ -77,7 +77,7 @@ class AuthController {
       const { id: userId, type: userType } = singleUser;
       const token = createToken({ userId, userType });
       const {
-        password: userPassword, isadmin, type, createdon, updatedon, ...signinDetails
+        password: userPassword, isadmin, createdon, updatedon, ...signinDetails
       } = singleUser;
       const newSignin = { token, ...signinDetails };
       return res.header('x-auth-token', token).status(200).json({

--- a/server/tests/auth.js
+++ b/server/tests/auth.js
@@ -33,6 +33,8 @@ describe('Auth Endpoints', () => {
             res.body.data[0].email.should.be.a('string');
             res.body.data[0].should.have.property('id');
             res.body.data[0].id.should.be.an('number');
+            res.body.data[0].should.have.property('type');
+            res.body.data[0].type.should.be.a('string');
             done();
           });
       } catch (error) {
@@ -117,6 +119,8 @@ describe('Auth Endpoints', () => {
             res.body.data[0].email.should.be.a('string');
             res.body.data[0].should.have.property('id');
             res.body.data[0].id.should.be.an('number');
+            res.body.data[0].should.have.property('type');
+            res.body.data[0].type.should.be.a('string');
             done();
           });
       } catch (error) {


### PR DESCRIPTION
### What does this PR do?
Includes the user's type in the response body upon signup/signin success

### Description of Task to be completed?
- Include user type in signin/signup response data
- Include user type in auth success response tests

### How should this be manually tested
1. Follow the instructions on the README file to start the development environment on your local machine.
2. In your terminal run ```curl --request POST http://localhost:3000/api/v1/auth/signup -d 'firstName=Mary&lastName=Wale&email=maryw@yahoo.com&password=mypassword&type=client' ```
3. Next run ```curl --request POST http://localhost:3000/api/v1/auth/signin -d 'email=maryw@yahoo.com&password=mypassword' ```
4. For both requests, you should get a response array of newly created user with user type included in the response body

### What are the relevant pivotal tracker stories?
[#165485037](https://www.pivotaltracker.com/story/show/165485037)