### PR TITLE
#165485516 Fix permission on get account by email route (JWT)

### DIFF
--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -16,10 +16,10 @@ const { userParamValidator } = userValidator;
 
 const { emailParamValidator } = authValidator;
 
-const { isAuth, levelThree, levelFive } = Authenticator;
+const { isAuth, levelThree } = Authenticator;
 
 router.get('/:userId', isAuth, levelThree, userParamValidator, validate, getUser);
 router.get('/', isAuth, levelThree, getAllUsers);
-router.get('/:email/accounts', isAuth, levelFive, emailParamValidator, validate, getUserAccounts);
+router.get('/:email/accounts', isAuth, emailParamValidator, validate, getUserAccounts);
 
 export default router;


### PR DESCRIPTION
### What does this PR do?
Changes permission level on get accounts by email route to general to allow user get accounts by email

### Description of Task to be completed?
- Change permission level on get accounts by email route to general

### How should this be manually tested
1. Follow the instructions on the README file to start the development environment on your local machine.
2. In your terminal run ```curl --request POST http://localhost:3000/api/v1/auth/signup -d 'firstName=John&lastName=Winston&email=validEmail&password=password&type=client' ``` Where **validEmail** is a valid email address
3. You should get a response object with a response status of **201** and a data array of a single object of signup details including an **id** and a **token**.
4. Run the following command ```curl -H "x-auth-token: token" --request POST http://localhost:3000/api/v1/accounts -d 'accountNumber=1029394848&owner=:id&type=savings&openingBalance=20000.40&status=active```. Where **token** and **id** are the from your signup details
5.  Run the following command ```curl -H "x-auth-token: token" --request GET http://localhost:3000/api/v1/users/email/accounts```
6. You should get a response array of accounts of user with given email

### What are the relevant pivotal tracker stories?
[#165485516](https://www.pivotaltracker.com/story/show/165485516)